### PR TITLE
startReaping after first acquire has been called

### DIFF
--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -2,12 +2,9 @@
 
 const Resource = require('./Resource').Resource;
 const PendingOperation = require('./PendingOperation').PendingOperation;
-const defer = require('./utils').defer;
 const now = require('./utils').now;
 const duration = require('./utils').duration;
-const checkRequiredTime = require('./utils').checkRequiredTime;
 const checkOptionalTime = require('./utils').checkOptionalTime;
-const timeout = require('./utils').timeout;
 const delay = require('./utils').delay;
 const reflect = require('./utils').reflect;
 const tryPromise = require('./utils').tryPromise;
@@ -88,8 +85,6 @@ class Pool {
     this.pendingCreates = [];
     this.pendingAcquires = [];
     this.destroyed = false;
-
-    this.interval = setInterval(() => this.check(), this.reapIntervalMillis);
   }
 
   numUsed() {
@@ -160,6 +155,12 @@ class Pool {
     });
 
     this.free = newFree;
+
+    //Pool is empty, stop reaping.
+    //Next .acquire will start reaping interval again.
+    if(this.used.length === 0) {
+      this._stopReaping();
+    }
   }
 
   destroy() {
@@ -224,6 +225,9 @@ class Pool {
       this.pendingAcquires.shift();
       this.free.pop();
       this.used.push(free.resolve());
+
+      //At least one active resource, start reaping
+      this._startReaping();
 
       pendingAcquire.resolve(free.resource);
     }
@@ -314,6 +318,12 @@ class Pool {
       // There's nothing we can do here but log the error. This would otherwise
       // leak out as an unhandled exception.
       this.log('Tarn: resource destroyer threw an exception ' + err.stack, 'warn');
+    }
+  }
+
+  _startReaping() {
+    if(!this.interval) {
+      this.interval = setInterval(() => this.check(), this.reapIntervalMillis);
     }
   }
 

--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -85,6 +85,7 @@ class Pool {
     this.pendingCreates = [];
     this.pendingAcquires = [];
     this.destroyed = false;
+    this.interval = null;
   }
 
   numUsed() {
@@ -135,6 +136,15 @@ class Pool {
     return false;
   }
 
+  isEmpty() {
+    return [
+      this.numFree(),
+      this.numUsed(),
+      this.numPendingAcquires(),
+      this.numPendingCreates(),
+    ].reduce((total, value) => total + value) === 0;
+  }
+
   check() {
     const timestamp = now();
     const newFree = [];
@@ -156,9 +166,9 @@ class Pool {
 
     this.free = newFree;
 
-    //Pool is empty, stop reaping.
+    //Pool is completely empty, stop reaping.
     //Next .acquire will start reaping interval again.
-    if(this.used.length === 0) {
+    if(this.isEmpty()) {
       this._stopReaping();
     }
   }


### PR DESCRIPTION
Not familiar with codebase, so this might be entirely wrong. The idea is to `stopReaping` when the pool is/becomes empty post-check and `startReaping` whenever there is at least one `used` *(array)* resource in the pool.

Calling `startReaping` in `acquire()` while `stopReaping` in `check()` would most likely result in a race-condition, so this feels more safe.

Relates to https://github.com/tgriesser/knex/issues/2510