### PR TITLE
then() should always return a promise

### DIFF
--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -197,6 +197,7 @@ class Pool {
           this.free.forEach(free => this._destroy(free.resource));
           this.free = [];
           this.pendingAcquires = [];
+          return null;
         })
     );
   }
@@ -276,8 +277,8 @@ class Pool {
 
     pendingCreate.promise
       .then(() => {
-        // Not returned on purpose.
         this._tryAcquireOrCreate();
+        return null;
       })
       .catch(err => {
         if (this.propagateCreateError && this.pendingAcquires.length !== 0) {
@@ -295,8 +296,11 @@ class Pool {
           pendingAcquire.possibleTimeoutCause = err;
         });
 
-        // Not returned on purpose.
-        delay(this.createRetryIntervalMillis).then(() => this._tryAcquireOrCreate());
+        delay(this.createRetryIntervalMillis)
+          .then(() => {
+            this._tryAcquireOrCreate();
+            return null;
+          });
       });
   }
 
@@ -310,6 +314,7 @@ class Pool {
         this.free.push(new Resource(resource));
 
         pendingCreate.resolve(resource);
+        return null;
       })
       .catch(err => {
         remove(this.pendingCreates, pendingCreate);


### PR DESCRIPTION
Every .then() creates a new promise and should either return a resolved or rejected promise up the promise chain. This PR fixes the code so that all calls to then() returns a valid resolved promise. 
In this case, a null ( which gets wrapped in a resolved promise). 

This is to eliminate the warning:
Warning: a promise was created in a handler but was not returned from it
