### PR TITLE
Add strict typings via TypeScript

### DIFF
--- a/lib/PendingOperation.d.ts
+++ b/lib/PendingOperation.d.ts
@@ -1,0 +1,11 @@
+import { Deferred } from './utils';
+export declare class PendingOperation<T> {
+  protected timeoutMillis: number;
+  possibleTimeoutCause: Error | null;
+  promise: Promise<T>;
+  protected deferred: Deferred<T>;
+  constructor(timeoutMillis: number);
+  abort(): void;
+  reject(err: Error): void;
+  resolve(value: T): void;
+}

--- a/lib/PendingOperation.js
+++ b/lib/PendingOperation.js
@@ -1,43 +1,37 @@
 'use strict';
-
-const TimeoutError = require('./TimeoutError').TimeoutError;
-const defer = require('./utils').defer;
-
+Object.defineProperty(exports, '__esModule', { value: true });
+const TimeoutError_1 = require('./TimeoutError');
+const utils_1 = require('./utils');
 class PendingOperation {
   constructor(timeoutMillis) {
-    this.deferred = defer();
+    this.timeoutMillis = timeoutMillis;
+    this.deferred = utils_1.defer();
     this.possibleTimeoutCause = null;
-
     this.promise = timeout(this.deferred.promise, timeoutMillis).catch(err => {
-      if (err instanceof TimeoutError) {
+      if (err instanceof TimeoutError_1.TimeoutError) {
         if (this.possibleTimeoutCause) {
-          err = new TimeoutError(this.possibleTimeoutCause.message);
+          err = new TimeoutError_1.TimeoutError(this.possibleTimeoutCause.message);
         } else {
-          err = new TimeoutError('operation timed out for an unknown reason');
+          err = new TimeoutError_1.TimeoutError('operation timed out for an unknown reason');
         }
       }
-
       return Promise.reject(err);
     });
   }
-
   abort() {
     this.reject(new Error('aborted'));
   }
-
   reject(err) {
     this.deferred.reject(err);
   }
-
   resolve(value) {
     this.deferred.resolve(value);
   }
 }
-
+exports.PendingOperation = PendingOperation;
 function timeout(promise, time) {
   return new Promise((resolve, reject) => {
-    const timeoutHandle = setTimeout(() => reject(new TimeoutError()), time);
-
+    const timeoutHandle = setTimeout(() => reject(new TimeoutError_1.TimeoutError()), time);
     promise
       .then(result => {
         clearTimeout(timeoutHandle);
@@ -49,7 +43,3 @@ function timeout(promise, time) {
       });
   });
 }
-
-module.exports = {
-  PendingOperation
-};

--- a/lib/Pool.d.ts
+++ b/lib/Pool.d.ts
@@ -1,0 +1,63 @@
+/// <reference types="node" />
+import { PendingOperation } from './PendingOperation';
+import { Resource } from './Resource';
+export interface PoolOptions<T> {
+  create: CallbackOrPromise<T>;
+  destroy: (resource: T) => any;
+  min: number;
+  max: number;
+  acquireTimeoutMillis?: number;
+  createTimeoutMillis?: number;
+  idleTimeoutMillis?: number;
+  createRetryIntervalMillis?: number;
+  reapIntervalMillis?: number;
+  log?: (msg: string) => any;
+  validate?: (resource: T) => boolean;
+  propagateCreateError?: boolean;
+}
+export declare class Pool<T> {
+  protected min: number;
+  protected max: number;
+  protected used: Resource<T>[];
+  protected free: Resource<T>[];
+  protected pendingCreates: PendingOperation<T>[];
+  protected pendingAcquires: PendingOperation<T>[];
+  protected interval: NodeJS.Timer | null;
+  protected destroyed: boolean;
+  protected propagateCreateError: boolean;
+  protected idleTimeoutMillis: number;
+  protected createRetryIntervalMillis: number;
+  protected reapIntervalMillis: number;
+  protected createTimeoutMillis: number;
+  protected acquireTimeoutMillis: number;
+  protected log: (msg: string, level: 'warn') => any;
+  protected creator: CallbackOrPromise<T>;
+  protected destroyer: (resource: T) => any;
+  protected validate: (resource: T) => boolean;
+  constructor(opt: PoolOptions<T>);
+  numUsed(): number;
+  numFree(): number;
+  numPendingAcquires(): number;
+  numPendingCreates(): number;
+  acquire(): PendingOperation<T>;
+  release(resource: T): boolean;
+  isEmpty(): boolean;
+  check(): void;
+  destroy(): Promise<
+    | import('./PromiseInspection').PromiseInspection<{}>
+    | import('./PromiseInspection').PromiseInspection<void>
+  >;
+  _tryAcquireOrCreate(): void;
+  _hasFreeResources(): boolean;
+  _doAcquire(): void;
+  _canAcquire(): boolean;
+  _validateResource(resource: T): boolean;
+  _shouldCreateMoreResources(): boolean;
+  _doCreate(): void;
+  _create(): PendingOperation<T>;
+  _destroy(resource: T): void;
+  _startReaping(): void;
+  _stopReaping(): void;
+}
+export declare type Callback<T> = (err: Error | null, resource: T) => any;
+export declare type CallbackOrPromise<T> = (cb: Callback<T>) => any | (() => Promise<T>);

--- a/lib/PromiseInspection.d.ts
+++ b/lib/PromiseInspection.d.ts
@@ -1,0 +1,18 @@
+export declare type PromiseInspectionArgs<T> =
+  | {
+      value: T;
+      error?: Error;
+    }
+  | {
+      value?: T;
+      error: Error;
+    };
+export declare class PromiseInspection<T> {
+  _value: T | void;
+  _error: Error | void;
+  constructor(args: PromiseInspectionArgs<T>);
+  value(): void | T;
+  reason(): void | Error;
+  isRejected(): boolean;
+  isFulfilled(): boolean;
+}

--- a/lib/PromiseInspection.js
+++ b/lib/PromiseInspection.js
@@ -1,28 +1,21 @@
 'use strict';
-
+Object.defineProperty(exports, '__esModule', { value: true });
 class PromiseInspection {
   constructor(args) {
     this._value = args.value;
     this._error = args.error;
   }
-
   value() {
     return this._value;
   }
-
   reason() {
     return this._error;
   }
-
   isRejected() {
     return !!this._error;
   }
-
   isFulfilled() {
     return !!this._value;
   }
 }
-
-module.exports = {
-  PromiseInspection
-};
+exports.PromiseInspection = PromiseInspection;

--- a/lib/Resource.d.ts
+++ b/lib/Resource.d.ts
@@ -1,0 +1,9 @@
+import { Deferred } from './utils';
+export declare class Resource<T> {
+  resource: T;
+  readonly timestamp: number;
+  protected deferred: Deferred<void>;
+  constructor(resource: T);
+  readonly promise: Promise<void>;
+  resolve(): Resource<T>;
+}

--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -1,25 +1,19 @@
 'use strict';
-
-const defer = require('./utils').defer;
-const now = require('./utils').now;
-
+Object.defineProperty(exports, '__esModule', { value: true });
+const utils_1 = require('./utils');
 class Resource {
   constructor(resource) {
     this.resource = resource;
-    this.timestamp = now();
-    this.deferred = defer();
+    this.resource = resource;
+    this.timestamp = utils_1.now();
+    this.deferred = utils_1.defer();
   }
-
   get promise() {
     return this.deferred.promise;
   }
-
   resolve() {
-    this.deferred.resolve();
+    this.deferred.resolve(undefined);
     return new Resource(this.resource);
   }
 }
-
-module.exports = {
-  Resource
-};
+exports.Resource = Resource;

--- a/lib/TimeoutError.d.ts
+++ b/lib/TimeoutError.d.ts
@@ -1,0 +1,1 @@
+export declare class TimeoutError extends Error {}

--- a/lib/TimeoutError.js
+++ b/lib/TimeoutError.js
@@ -1,7 +1,4 @@
 'use strict';
-
+Object.defineProperty(exports, '__esModule', { value: true });
 class TimeoutError extends Error {}
-
-module.exports = {
-  TimeoutError
-};
+exports.TimeoutError = TimeoutError;

--- a/lib/tarn.d.ts
+++ b/lib/tarn.d.ts
@@ -1,0 +1,3 @@
+import { Pool } from './Pool';
+import { TimeoutError } from './TimeoutError';
+export { Pool, TimeoutError };

--- a/lib/tarn.js
+++ b/lib/tarn.js
@@ -1,9 +1,10 @@
 'use strict';
-
-const Pool = require('./Pool').Pool;
-const TimeoutError = require('./TimeoutError').TimeoutError;
-
+Object.defineProperty(exports, '__esModule', { value: true });
+const Pool_1 = require('./Pool');
+exports.Pool = Pool_1.Pool;
+const TimeoutError_1 = require('./TimeoutError');
+exports.TimeoutError = TimeoutError_1.TimeoutError;
 module.exports = {
-  Pool,
-  TimeoutError
+  Pool: Pool_1.Pool,
+  TimeoutError: TimeoutError_1.TimeoutError
 };

--- a/lib/utils.d.ts
+++ b/lib/utils.d.ts
@@ -1,0 +1,16 @@
+import { PromiseInspection } from './PromiseInspection';
+export interface Deferred<T> {
+  resolve: (val: T) => any;
+  reject: <T>(err: T) => any;
+  promise: Promise<T>;
+}
+export declare function defer<T>(): Deferred<T>;
+export declare function now(): number;
+export declare function duration(t1: number, t2: number): number;
+export declare function checkOptionalTime(time?: number): boolean;
+export declare function checkRequiredTime(time: number): boolean;
+export declare function delay(millis: number): Promise<{}>;
+export declare function reflect<T>(
+  promise: Promise<T>
+): Promise<PromiseInspection<T> | PromiseInspection<{}>>;
+export declare function tryPromise<T>(cb: () => T | PromiseLike<T>): Promise<T>;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,57 +1,53 @@
 'use strict';
-
-const PromiseInspection = require('./PromiseInspection').PromiseInspection;
-
+Object.defineProperty(exports, '__esModule', { value: true });
+const PromiseInspection_1 = require('./PromiseInspection');
 function defer() {
   let resolve = null;
   let reject = null;
-
   const promise = new Promise((resolver, rejecter) => {
     resolve = resolver;
     reject = rejecter;
   });
-
   return {
     promise,
     resolve,
     reject
   };
 }
-
+exports.defer = defer;
 function now() {
   return Date.now();
 }
-
+exports.now = now;
 function duration(t1, t2) {
   return Math.abs(t2 - t1);
 }
-
+exports.duration = duration;
 function checkOptionalTime(time) {
   if (typeof time === 'undefined') {
     return true;
-  } else {
-    return checkRequiredTime(time);
   }
+  return checkRequiredTime(time);
 }
-
+exports.checkOptionalTime = checkOptionalTime;
 function checkRequiredTime(time) {
   return typeof time === 'number' && time === Math.round(time) && time > 0;
 }
-
+exports.checkRequiredTime = checkRequiredTime;
 function delay(millis) {
   return new Promise(resolve => setTimeout(resolve, millis));
 }
-
+exports.delay = delay;
 function reflect(promise) {
   return promise
     .then(value => {
-      return new PromiseInspection({ value });
+      return new PromiseInspection_1.PromiseInspection({ value });
     })
     .catch(error => {
-      return new PromiseInspection({ error });
+      return new PromiseInspection_1.PromiseInspection({ error });
     });
 }
-
+exports.reflect = reflect;
 function tryPromise(cb) {
   try {
     const result = cb();
@@ -60,14 +56,4 @@ function tryPromise(cb) {
     return Promise.reject(err);
   }
 }
-
-module.exports = {
-  now,
-  defer,
-  delay,
-  reflect,
-  duration,
-  tryPromise,
-  checkOptionalTime,
-  checkRequiredTime
-};
+exports.tryPromise = tryPromise;

--- a/package.json
+++ b/package.json
@@ -3,10 +3,15 @@
   "version": "1.1.4",
   "description": "Simple and robust resource pool for node.js",
   "main": "lib/tarn.js",
+  "types": "lib/tarn.d.ts",
   "license": "MIT",
   "scripts": {
     "test": "mocha --slow 10 --timeout 5000 --reporter spec tests.js",
-    "test-bail": "mocha --slow 10 --timeout 5000 --reporter spec --bail tests.js"
+    "test-bail": "mocha --slow 10 --timeout 5000 --reporter spec --bail tests.js",
+    "build": "tsc",
+    "clean": "rm -rf lib",
+    "prepublishOnly": "tsc",
+    "format": "prettier **/*.{js,ts} --write"
   },
   "author": {
     "name": "Sami Koskimäki",
@@ -30,10 +35,21 @@
     "LICENSE",
     "lib/*"
   ],
+  "lint-staged": {
+    "*.{js,ts}": [
+      "prettier --write",
+      "git add"
+    ]
+  },
   "devDependencies": {
     "bluebird": "^3.5.1",
     "expect.js": "^0.3.1",
-    "mocha": "^4.1.0"
+    "mocha": "^4.1.0",
+    "typescript": "2.9.1",
+    "@types/node": "^10.5.2",
+    "prettier": "^1.13.7",
+    "lint-staged": "^7.2.0",
+    "husky": "^0.14.3"
   },
   "dependencies": {}
 }

--- a/src/PendingOperation.ts
+++ b/src/PendingOperation.ts
@@ -1,0 +1,53 @@
+import { TimeoutError } from './TimeoutError';
+import { defer, Deferred } from './utils';
+
+export class PendingOperation<T> {
+  public possibleTimeoutCause: Error | null;
+  public promise: Promise<T>;
+  protected deferred: Deferred<T>;
+
+  constructor(protected timeoutMillis: number) {
+    this.deferred = defer<T>();
+    this.possibleTimeoutCause = null;
+
+    this.promise = timeout(this.deferred.promise, timeoutMillis).catch(err => {
+      if (err instanceof TimeoutError) {
+        if (this.possibleTimeoutCause) {
+          err = new TimeoutError(this.possibleTimeoutCause.message);
+        } else {
+          err = new TimeoutError('operation timed out for an unknown reason');
+        }
+      }
+
+      return Promise.reject(err);
+    });
+  }
+
+  abort() {
+    this.reject(new Error('aborted'));
+  }
+
+  reject(err: Error) {
+    this.deferred.reject(err);
+  }
+
+  resolve(value: T) {
+    this.deferred.resolve(value);
+  }
+}
+
+function timeout<T>(promise: Promise<T>, time: number) {
+  return new Promise<T>((resolve, reject) => {
+    const timeoutHandle = setTimeout(() => reject(new TimeoutError()), time);
+
+    promise
+      .then(result => {
+        clearTimeout(timeoutHandle);
+        resolve(result);
+      })
+      .catch(err => {
+        clearTimeout(timeoutHandle);
+        reject(err);
+      });
+  });
+}

--- a/src/PromiseInspection.ts
+++ b/src/PromiseInspection.ts
@@ -1,0 +1,35 @@
+export type PromiseInspectionArgs<T> =
+  | {
+      value: T;
+      error?: Error;
+    }
+  | {
+      value?: T;
+      error: Error;
+    };
+
+export class PromiseInspection<T> {
+  _value: T | void;
+  _error: Error | void;
+
+  constructor(args: PromiseInspectionArgs<T>) {
+    this._value = args.value;
+    this._error = args.error;
+  }
+
+  value() {
+    return this._value;
+  }
+
+  reason() {
+    return this._error;
+  }
+
+  isRejected() {
+    return !!this._error;
+  }
+
+  isFulfilled() {
+    return !!this._value;
+  }
+}

--- a/src/Resource.ts
+++ b/src/Resource.ts
@@ -1,0 +1,21 @@
+import { defer, now, Deferred } from './utils';
+
+export class Resource<T> {
+  readonly timestamp: number;
+  protected deferred: Deferred<void>;
+
+  constructor(public resource: T) {
+    this.resource = resource;
+    this.timestamp = now();
+    this.deferred = defer<void>();
+  }
+
+  get promise() {
+    return this.deferred.promise;
+  }
+
+  resolve() {
+    this.deferred.resolve(undefined);
+    return new Resource(this.resource);
+  }
+}

--- a/src/TimeoutError.ts
+++ b/src/TimeoutError.ts
@@ -1,0 +1,1 @@
+export class TimeoutError extends Error {}

--- a/src/tarn.ts
+++ b/src/tarn.ts
@@ -1,0 +1,9 @@
+import { Pool } from './Pool';
+import { TimeoutError } from './TimeoutError';
+
+export { Pool, TimeoutError };
+
+module.exports = {
+  Pool,
+  TimeoutError
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,65 @@
+import { PromiseInspection } from './PromiseInspection';
+
+export interface Deferred<T> {
+  resolve: (val: T) => any;
+  reject: <T>(err: T) => any;
+  promise: Promise<T>;
+}
+
+export function defer<T>(): Deferred<T> {
+  let resolve: any = null;
+  let reject: any = null;
+
+  const promise = new Promise<T>((resolver, rejecter) => {
+    resolve = resolver;
+    reject = rejecter;
+  });
+
+  return {
+    promise,
+    resolve,
+    reject
+  } as Deferred<T>;
+}
+
+export function now() {
+  return Date.now();
+}
+
+export function duration(t1: number, t2: number) {
+  return Math.abs(t2 - t1);
+}
+
+export function checkOptionalTime(time?: number) {
+  if (typeof time === 'undefined') {
+    return true;
+  }
+  return checkRequiredTime(time);
+}
+
+export function checkRequiredTime(time: number) {
+  return typeof time === 'number' && time === Math.round(time) && time > 0;
+}
+
+export function delay(millis: number) {
+  return new Promise(resolve => setTimeout(resolve, millis));
+}
+
+export function reflect<T>(promise: Promise<T>) {
+  return promise
+    .then(value => {
+      return new PromiseInspection({ value });
+    })
+    .catch(error => {
+      return new PromiseInspection({ error });
+    });
+}
+
+export function tryPromise<T>(cb: () => T | PromiseLike<T>) {
+  try {
+    const result = cb();
+    return Promise.resolve(result);
+  } catch (err) {
+    return Promise.reject(err);
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./lib",
+    "strict": true,
+    "esModuleInterop": true,
+    "target": "es2016",
+    "noImplicitAny": true,
+    "declaration": true,
+    "module": "commonjs"
+  }
+}


### PR DESCRIPTION
Hey @koskimas not sure if this is something you're interested in, but as I'm preparing a path forward for knex to begin to use TypeScript for things I was looking at what dependencies have type definitions via DefinitelyTyped. As tarn didn't I thought I'd make a PR to add them, but then instead took a few minutes and added types to the whole module.

As you can probably tell from the diff, there aren't any implementation changes, just a few things around the emitted `require`'s. If you'd rather keep things simpler in pure JS with no build step, I can just consolidate all of the type definitions into a single `d.ts` and reopen with a PR for that.