### PR TITLE
Handle opt.destroy() being a promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ const pool = new Pool({
   // if a resource cannot be acquired
   createTimeoutMillis: 30000,
 
+  // destroy operations are awaited for at most this many milliseconds
+  // new resources will be created after this timeout
+  destroyTimeoutMillis: 200,
+
   // free resouces are destroyed after this many milliseconds
   idleTimeoutMillis: 30000,
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ const pool = new Pool({
 
   // destroy operations are awaited for at most this many milliseconds
   // new resources will be created after this timeout
-  destroyTimeoutMillis: 200,
+  destroyTimeoutMillis: 5000,
 
   // free resouces are destroyed after this many milliseconds
   idleTimeoutMillis: 30000,

--- a/lib/Pool.d.ts
+++ b/lib/Pool.d.ts
@@ -56,6 +56,7 @@ export declare class Pool<T> {
   _doCreate(): void;
   _create(): PendingOperation<T>;
   _destroy(resource: T): any;
+  _logError(err: Error): void;
   _startReaping(): void;
   _stopReaping(): void;
 }

--- a/lib/Pool.d.ts
+++ b/lib/Pool.d.ts
@@ -8,6 +8,7 @@ export interface PoolOptions<T> {
   max: number;
   acquireTimeoutMillis?: number;
   createTimeoutMillis?: number;
+  destroyTimeoutMillis?: number;
   idleTimeoutMillis?: number;
   createRetryIntervalMillis?: number;
   reapIntervalMillis?: number;
@@ -29,6 +30,7 @@ export declare class Pool<T> {
   protected createRetryIntervalMillis: number;
   protected reapIntervalMillis: number;
   protected createTimeoutMillis: number;
+  protected destroyTimeoutMillis: number;
   protected acquireTimeoutMillis: number;
   protected log: (msg: string, level: 'warn') => any;
   protected creator: CallbackOrPromise<T>;
@@ -55,7 +57,7 @@ export declare class Pool<T> {
   _shouldCreateMoreResources(): boolean;
   _doCreate(): void;
   _create(): PendingOperation<T>;
-  _destroy(resource: T): any;
+  _destroy(resource: T): Promise<any>;
   _logError(err: Error): void;
   _startReaping(): void;
   _stopReaping(): void;

--- a/lib/Pool.d.ts
+++ b/lib/Pool.d.ts
@@ -55,7 +55,7 @@ export declare class Pool<T> {
   _shouldCreateMoreResources(): boolean;
   _doCreate(): void;
   _create(): PendingOperation<T>;
-  _destroy(resource: T): void;
+  _destroy(resource: T): any;
   _startReaping(): void;
   _stopReaping(): void;
 }

--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -261,12 +261,20 @@ class Pool {
   }
   _destroy(resource) {
     try {
-      return this.destroyer(resource);
+      const retVal = this.destroyer(resource);
+      if (retVal && retVal.catch) {
+        // There's nothing we can do here but log the error.
+        retVal.catch(this._logError.bind(this));
+      }
+      return retVal;
     } catch (err) {
       // There's nothing we can do here but log the error. This would otherwise
       // leak out as an unhandled exception.
-      this.log('Tarn: resource destroyer threw an exception ' + err.stack, 'warn');
+      this._logError(err);
     }
+  }
+  _logError(err) {
+    this.log('Tarn: resource destroyer threw an exception ' + err.stack, 'warn');
   }
   _startReaping() {
     if (!this.interval) {

--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -32,6 +32,11 @@ class Pool {
         'Tarn: invalid opt.createTimeoutMillis ' + JSON.stringify(opt.createTimeoutMillis)
       );
     }
+    if (!utils_1.checkOptionalTime(opt.destroyTimeoutMillis)) {
+      throw new Error(
+        'Tarn: invalid opt.destroyTimeoutMillis ' + JSON.stringify(opt.destroyTimeoutMillis)
+      );
+    }
     if (!utils_1.checkOptionalTime(opt.idleTimeoutMillis)) {
       throw new Error(
         'Tarn: invalid opt.idleTimeoutMillis ' + JSON.stringify(opt.idleTimeoutMillis)
@@ -54,6 +59,7 @@ class Pool {
     this.log = opt.log || (() => {});
     this.acquireTimeoutMillis = opt.acquireTimeoutMillis || 30000;
     this.createTimeoutMillis = opt.createTimeoutMillis || 30000;
+    this.destroyTimeoutMillis = opt.destroyTimeoutMillis || 200;
     this.idleTimeoutMillis = opt.idleTimeoutMillis || 30000;
     this.reapIntervalMillis = opt.reapIntervalMillis || 1000;
     this.createRetryIntervalMillis = opt.createRetryIntervalMillis || 200;
@@ -155,7 +161,21 @@ class Pool {
         })
         .then(() => {
           // Now we can destroy all the freed resources.
-          return Promise.all(this.free.map(free => this._destroy(free.resource)));
+          return Promise.all(
+            this.free.map(free => {
+              const pendingDestroy = new PendingOperation_1.PendingOperation(
+                this.destroyTimeoutMillis
+              );
+              this._destroy(free.resource)
+                .then(() => {
+                  pendingDestroy.resolve(free.resource);
+                })
+                .catch(err => {
+                  pendingDestroy.reject(err);
+                });
+              return utils_1.reflect(pendingDestroy.promise);
+            })
+          );
         })
         .then(() => {
           this.free = [];
@@ -269,11 +289,12 @@ class Pool {
         // There's nothing we can do here but log the error.
         retVal.catch(this._logError.bind(this));
       }
-      return retVal;
+      return Promise.resolve(retVal);
     } catch (err) {
       // There's nothing we can do here but log the error. This would otherwise
       // leak out as an unhandled exception.
       this._logError(err);
+      return Promise.resolve();
     }
   }
   _logError(err) {

--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -59,7 +59,7 @@ class Pool {
     this.log = opt.log || (() => {});
     this.acquireTimeoutMillis = opt.acquireTimeoutMillis || 30000;
     this.createTimeoutMillis = opt.createTimeoutMillis || 30000;
-    this.destroyTimeoutMillis = opt.destroyTimeoutMillis || 200;
+    this.destroyTimeoutMillis = opt.destroyTimeoutMillis || 5000;
     this.idleTimeoutMillis = opt.idleTimeoutMillis || 30000;
     this.reapIntervalMillis = opt.reapIntervalMillis || 1000;
     this.createRetryIntervalMillis = opt.createRetryIntervalMillis || 200;
@@ -161,21 +161,7 @@ class Pool {
         })
         .then(() => {
           // Now we can destroy all the freed resources.
-          return Promise.all(
-            this.free.map(free => {
-              const pendingDestroy = new PendingOperation_1.PendingOperation(
-                this.destroyTimeoutMillis
-              );
-              this._destroy(free.resource)
-                .then(() => {
-                  pendingDestroy.resolve(free.resource);
-                })
-                .catch(err => {
-                  pendingDestroy.reject(err);
-                });
-              return utils_1.reflect(pendingDestroy.promise);
-            })
-          );
+          return Promise.all(this.free.map(free => utils_1.reflect(this._destroy(free.resource))));
         })
         .then(() => {
           this.free = [];
@@ -285,9 +271,17 @@ class Pool {
       // When it's synchronous, errors are handled by the try/catch
       // When it's asynchronous, errors are handled by .catch()
       const retVal = this.destroyer(resource);
-      if (retVal && retVal.catch) {
-        // There's nothing we can do here but log the error.
-        retVal.catch(this._logError.bind(this));
+      if (retVal && retVal.then && retVal.catch) {
+        const pendingDestroy = new PendingOperation_1.PendingOperation(this.destroyTimeoutMillis);
+        retVal
+          .then(() => {
+            pendingDestroy.resolve(resource);
+          })
+          .catch(err => {
+            pendingDestroy.reject(err);
+          });
+        // In case of an error there's nothing we can do here but log it.
+        return pendingDestroy.promise.catch(this._logError.bind(this));
       }
       return Promise.resolve(retVal);
     } catch (err) {

--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -281,7 +281,7 @@ class Pool {
             pendingDestroy.reject(err);
           });
         // In case of an error there's nothing we can do here but log it.
-        return pendingDestroy.promise.catch(this._logError.bind(this));
+        return pendingDestroy.promise.catch(err => this._logError(err));
       }
       return Promise.resolve(retVal);
     } catch (err) {

--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -128,8 +128,8 @@ class Pool {
       }
     });
     this.free = newFree;
-    //Pool is completely empty, stop reaping.
-    //Next .acquire will start reaping interval again.
+    // Pool is completely empty, stop reaping.
+    // Next .acquire will start reaping interval again.
     if (this.isEmpty()) {
       this._stopReaping();
     }
@@ -155,7 +155,9 @@ class Pool {
         })
         .then(() => {
           // Now we can destroy all the freed resources.
-          this.free.forEach(free => this._destroy(free.resource));
+          return Promise.all(this.free.map(free => this._destroy(free.resource)));
+        })
+        .then(() => {
           this.free = [];
           this.pendingAcquires = [];
         })
@@ -259,7 +261,7 @@ class Pool {
   }
   _destroy(resource) {
     try {
-      this.destroyer(resource);
+      return this.destroyer(resource);
     } catch (err) {
       // There's nothing we can do here but log the error. This would otherwise
       // leak out as an unhandled exception.

--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -261,6 +261,9 @@ class Pool {
   }
   _destroy(resource) {
     try {
+      // this.destroyer can be both synchronous and asynchronous.
+      // When it's synchronous, errors are handled by the try/catch
+      // When it's asynchronous, errors are handled by .catch()
       const retVal = this.destroyer(resource);
       if (retVal && retVal.catch) {
         // There's nothing we can do here but log the error.

--- a/src/Pool.ts
+++ b/src/Pool.ts
@@ -192,8 +192,8 @@ export class Pool<T> {
 
     this.free = newFree;
 
-    //Pool is completely empty, stop reaping.
-    //Next .acquire will start reaping interval again.
+    // Pool is completely empty, stop reaping.
+    // Next .acquire will start reaping interval again.
     if (this.isEmpty()) {
       this._stopReaping();
     }
@@ -221,7 +221,9 @@ export class Pool<T> {
         })
         .then(() => {
           // Now we can destroy all the freed resources.
-          this.free.forEach(free => this._destroy(free.resource));
+          return Promise.all(this.free.map(free => this._destroy(free.resource)));
+        })
+        .then(() => {
           this.free = [];
           this.pendingAcquires = [];
         })
@@ -349,7 +351,7 @@ export class Pool<T> {
 
   _destroy(resource: T) {
     try {
-      this.destroyer(resource);
+      return this.destroyer(resource);
     } catch (err) {
       // There's nothing we can do here but log the error. This would otherwise
       // leak out as an unhandled exception.

--- a/src/Pool.ts
+++ b/src/Pool.ts
@@ -351,6 +351,9 @@ export class Pool<T> {
 
   _destroy(resource: T) {
     try {
+      // this.destroyer can be both synchronous and asynchronous.
+      // When it's synchronous, errors are handled by the try/catch
+      // When it's asynchronous, errors are handled by .catch()
       const retVal = this.destroyer(resource);
       if (retVal && retVal.catch) {
         // There's nothing we can do here but log the error.

--- a/src/Pool.ts
+++ b/src/Pool.ts
@@ -375,7 +375,7 @@ export class Pool<T> {
           });
 
         // In case of an error there's nothing we can do here but log it.
-        return pendingDestroy.promise.catch(this._logError.bind(this));
+        return pendingDestroy.promise.catch(err => this._logError(err));
       }
       return Promise.resolve(retVal);
     } catch (err) {

--- a/src/Pool.ts
+++ b/src/Pool.ts
@@ -351,12 +351,21 @@ export class Pool<T> {
 
   _destroy(resource: T) {
     try {
-      return this.destroyer(resource);
+      const retVal = this.destroyer(resource);
+      if (retVal && retVal.catch) {
+        // There's nothing we can do here but log the error.
+        retVal.catch(this._logError.bind(this));
+      }
+      return retVal;
     } catch (err) {
       // There's nothing we can do here but log the error. This would otherwise
       // leak out as an unhandled exception.
-      this.log('Tarn: resource destroyer threw an exception ' + err.stack, 'warn');
+      this._logError(err);
     }
+  }
+
+  _logError(err: Error) {
+    this.log('Tarn: resource destroyer threw an exception ' + err.stack, 'warn');
   }
 
   _startReaping() {

--- a/tests.js
+++ b/tests.js
@@ -230,6 +230,48 @@ describe('Tarn', () => {
       });
     });
 
+    it('should fail if a non-integer opt.destroyTimeoutMillis is given', () => {
+      expect(() => {
+        pool = new Pool({
+          create: () => {},
+          destroy() {},
+          min: 2,
+          max: 10,
+          destroyTimeoutMillis: '10'
+        });
+      }).to.throwException(err => {
+        expect(err.message).to.equal('Tarn: invalid opt.destroyTimeoutMillis "10"');
+      });
+    });
+
+    it('should fail if a negative opt.destroyTimeoutMillis is given', () => {
+      expect(() => {
+        pool = new Pool({
+          create: () => {},
+          destroy() {},
+          min: 2,
+          max: 10,
+          destroyTimeoutMillis: -10
+        });
+      }).to.throwException(err => {
+        expect(err.message).to.equal('Tarn: invalid opt.destroyTimeoutMillis -10');
+      });
+    });
+
+    it('should fail if a zero opt.destroyTimeoutMillis is given', () => {
+      expect(() => {
+        pool = new Pool({
+          create: () => {},
+          destroy() {},
+          min: 2,
+          max: 10,
+          destroyTimeoutMillis: 0
+        });
+      }).to.throwException(err => {
+        expect(err.message).to.equal('Tarn: invalid opt.destroyTimeoutMillis 0');
+      });
+    });
+
     it('should fail if a non-integer opt.idleTimeoutMillis is given', () => {
       expect(() => {
         pool = new Pool({


### PR DESCRIPTION
knex.js passes a function as `opt.destroy` that creates a promise, so I believe the `.destroy()` should await completion. My PR works the same as previously if `opt.destroy` does not create a promise.

This was found via bluebird highlighting this promise creation. 