### PR TITLE
Explicitly silence bluebird warnings

### DIFF
--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -223,6 +223,7 @@ class Pool {
       .then(() => {
         // Not returned on purpose.
         this._tryAcquireOrCreate();
+        return null;
       })
       .catch(err => {
         if (this.propagateCreateError && this.pendingAcquires.length !== 0) {
@@ -249,11 +250,15 @@ class Pool {
       .then(resource => {
         remove(this.pendingCreates, pendingCreate);
         this.free.push(new Resource_1.Resource(resource));
+        // Not returned on purpose.
         pendingCreate.resolve(resource);
+        return null;
       })
       .catch(err => {
         remove(this.pendingCreates, pendingCreate);
+        // Not returned on purpose.
         pendingCreate.reject(err);
+        return null;
       });
     return pendingCreate;
   }

--- a/src/Pool.ts
+++ b/src/Pool.ts
@@ -305,6 +305,7 @@ export class Pool<T> {
       .then(() => {
         // Not returned on purpose.
         this._tryAcquireOrCreate();
+        return null;
       })
       .catch(err => {
         if (this.propagateCreateError && this.pendingAcquires.length !== 0) {
@@ -336,12 +337,16 @@ export class Pool<T> {
         remove(this.pendingCreates, pendingCreate);
         this.free.push(new Resource(resource));
 
+        // Not returned on purpose.
         pendingCreate.resolve(resource);
+        return null;
       })
       .catch(err => {
         remove(this.pendingCreates, pendingCreate);
 
+        // Not returned on purpose.
         pendingCreate.reject(err);
+        return null;
       });
 
     return pendingCreate;


### PR DESCRIPTION
As mentioned in https://github.com/Vincit/tarn.js/issues/5#issuecomment-448897791, this PR explicitly silences the bluebird warnings. Since it got a bit of hate, it is worth pointing out that those warnings identified this: https://github.com/Vincit/tarn.js/pull/16

