### PR TITLE
Check for pending validations before waiting on an interval

### DIFF
--- a/src/Pool.ts
+++ b/src/Pool.ts
@@ -282,6 +282,10 @@ export class Pool<T> {
         .then(() => {
           // poll every 100ms and wait that all validations are ready
           return new Promise((resolve, reject) => {
+            if (this.numPendingValidations() === 0) {
+              resolve();
+              return;
+            }
             const interval = setInterval(() => {
               if (this.numPendingValidations() === 0) {
                 clearInterval(interval);


### PR DESCRIPTION
With the the async validations destroy will wait 100ms minimum to resolve.  This exposed a race condition in my code that I am fixing but I also thought it might be a good idea to resolve immediately if there are no pending validations.