### PR TITLE
Wait for pending validations instead of checking on interval

### DIFF
--- a/src/Pool.ts
+++ b/src/Pool.ts
@@ -280,19 +280,9 @@ export class Pool<T> {
     return reflect(
       Promise.all(this.pendingCreates.map(create => reflect(create.promise)))
         .then(() => {
-          // poll every 100ms and wait that all validations are ready
-          return new Promise((resolve, reject) => {
-            if (this.numPendingValidations() === 0) {
-              resolve();
-              return;
-            }
-            const interval = setInterval(() => {
-              if (this.numPendingValidations() === 0) {
-                clearInterval(interval);
-                resolve();
-              }
-            }, 100);
-          });
+          return Promise.all(
+            this.pendingValidations.map(validation => reflect(validation.promise))
+          );
         })
         .then(() => {
           // Wait for all the used resources to be freed.

--- a/tests.js
+++ b/tests.js
@@ -1421,6 +1421,31 @@ describe('Tarn', () => {
           expect(resources[3].destroyed).to.be.ok();
         });
     });
+    it('should destroy immediately if there are no async validations', done => {
+      pool = new Pool({
+        create: () => {
+          return Promise.resolve({});
+        },
+        destroy(res) {
+          return Promise.resolve({});
+        },
+        validate(res) {
+          return true;
+        },
+        reapIntervalMillis: 10,
+        idleTimeoutMillis: 1,
+        min: 0,
+        max: 10
+      });
+      let destroyed = false;
+      setImmediate(() => {
+        expect(destroyed).to.equal(true);
+        done();
+      });
+      pool.destroy().then(() => {
+        destroyed = true;
+      });
+    });
   });
 
   describe('acquireTimeout', () => {


### PR DESCRIPTION
After looking through the code I thought it might be better to wait for the promises to resolve instead of checking the count on a timer.  I also added a regression which I tested by checking out the 2.0.0 version of tarn.js and writing this test that passes, then I checked out the version before my other fix and see that it failed, and now it is passing on this commit and the previous fix.