### PR TITLE
Only resolve a pending acquire when the pending acquire is not already rejected

### DIFF
--- a/src/Pool.ts
+++ b/src/Pool.ts
@@ -433,7 +433,10 @@ export class Pool<T> {
               pendingAcquire.resolve(free.resource);
             } else {
               remove(this.used, free);
-              this._destroy(free.resource);
+              // Only destroy the resource if the validation has failed
+              if (!validationSuccess) {
+                this._destroy(free.resource);
+              }
 
               // is acquire was canceled, failed or timed out already
               // no need to return it to pending queries

--- a/src/Pool.ts
+++ b/src/Pool.ts
@@ -427,7 +427,7 @@ export class Pool<T> {
         })
         .then(validationSuccess => {
           try {
-            if (validationSuccess) {
+            if (validationSuccess && !pendingAcquire.isRejected) {
               // At least one active resource exist, start reaping.
               this._startReaping();
               pendingAcquire.resolve(free.resource);


### PR DESCRIPTION
We are having an issue with the [node-mssql](https://github.com/tediousjs/node-mssql) library where the number of available pool connections seem to slowly get lower. After some debugging I've found the culprit: The `_doAcquire` doesn't check if a pending acquire has already been rejected. In this case what happens is:

```
acquire 1 request
acquire 1 succeeded
acquire 2 request
acquire 1 released
acquire 2 validation
acquire 2 aborted
acquire 2 validation finished
```

After the validation has finished, it will resolve. Although in this case the pending request was already aborted and thus the resolve will never be handled, making the resource get into a state of limbo.

To work around this issue, I've added a check that only resolves when the validation succeeds and the `pendingAcquire` is not already rejected. If the validation has succeeded and `pendingAcquire` has been rejected, it will not destroy the resource but just give the resource back to the pool.