### PR TITLE
Valid resources with rejected acquires should be returned to the pool

### DIFF
--- a/src/Pool.ts
+++ b/src/Pool.ts
@@ -433,7 +433,10 @@ export class Pool<T> {
               pendingAcquire.resolve(free.resource);
             } else {
               remove(this.used, free);
-              this._destroy(free.resource);
+              // Only destroy the resource if the validation has failed
+              if (!validationSuccess) {
+                this._destroy(free.resource);
+              }
 
               // is acquire was canceled, failed or timed out already
               // no need to return it to pending queries

--- a/src/Pool.ts
+++ b/src/Pool.ts
@@ -427,7 +427,7 @@ export class Pool<T> {
         })
         .then(validationSuccess => {
           try {
-            if (validationSuccess) {
+            if (validationSuccess && !pendingAcquire.isRejected) {
               // At least one active resource exist, start reaping.
               this._startReaping();
               pendingAcquire.resolve(free.resource);


### PR DESCRIPTION
Supersedes #67 

This adds a test for the expected behaviour (which fails without the patch) and improves on the good work by @pkeuter.

I noticed two things that looked amiss:

1. The valid resource was not added to the pool of free resources if validation was successful, leaving a resource potentially unreferenced/orphaned going forward.
2. The call to try the acquire loop again should only run if the resource was destroyed (as is the current behaviour)