### PR TITLE
Move @types/node to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     ]
   },
   "devDependencies": {
-    "@types/node": "^10.17.17",
     "@typescript-eslint/eslint-plugin": "^2.21.0",
     "@typescript-eslint/parser": "^2.21.0",
     "bluebird": "^3.7.2",
@@ -62,5 +61,7 @@
     "prettier": "^1.19.1",
     "typescript": "3.8.3"
   },
-  "dependencies": {}
+  "dependencies": {
+    "@types/node": "^10.17.17"
+  }
 }


### PR DESCRIPTION
Resolves https://github.com/Vincit/tarn.js/issues/64.

Error:
```
../../.yarn/cache/tarn-npm-3.0.2-4324dc10b0-27a69658f0.zip/node_modules/tarn/dist/Pool.d.ts:1:23 - error TS2688: Cannot find type definition file for 'node'.

1 /// <reference types="node" />
                        ~~~~


Found 1 error.
```