### PR TITLE
Updated documentation for idleTimeoutMillis

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ const pool = new Pool({
   // new resources will be created after this timeout
   destroyTimeoutMillis: 5000,
 
-  // free resouces are destroyed after this many milliseconds
+  // Free resources are destroyed after this many milliseconds.
+  // Note that if min > 0, some resources may be kept alive for longer.
+  // To reliably destroy all idle resources, set min to 0.
   idleTimeoutMillis: 30000,
 
   // how often to check for idle resources to destroy


### PR DESCRIPTION
It took me a long time to figure out why `idleTimeoutMillis` wasn't applying to all my connections. Some of them were kept open for hours, became stale and caused all sorts of trouble.

After lots of debugging, I realised that the `min` option was the culprit, defaulting to 2 in Knex.
The idle timeout is only applied if there are more connections than the minimum.

It seems like a good idea to document this behavior so others could figure it out more easily 🙂